### PR TITLE
SlackStatus, PostToSlack: Switch python for macOS 12.3

### DIFF
--- a/src/post-to-slack/default.sh
+++ b/src/post-to-slack/default.sh
@@ -7,7 +7,8 @@ else
 fi
 
 function escape_for_json(){
-  echo -n "$1" | python -c 'import json,sys; print json.dumps(sys.stdin.read())'
+  py=$(command -v python3 || command -v python)
+  echo -n "$1" | $py -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
 }
 
 USERNAME=$(escape_for_json "$KMPARAM_Username")

--- a/src/set-slack-status/default.sh
+++ b/src/set-slack-status/default.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 function escape_for_json(){
-  echo -n "$1" | python -c 'import json,sys; print json.dumps(sys.stdin.read())'
+  py=$(command -v python3 || command -v python)
+  echo -n "$1" | $py -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
 }
 
 emoji=$(escape_for_json "$KMPARAM_Status_emoji")


### PR DESCRIPTION
Fixes #7 

Switch the python executable depending on the version installed.